### PR TITLE
fix: shrinkwrap commit fails if on dev dependency update

### DIFF
--- a/lib/update-shrinkwrap.js
+++ b/lib/update-shrinkwrap.js
@@ -25,10 +25,12 @@ module.exports = function updateShrinkwrap (dependency, commitMessage, callback)
     exec(`npm install ${flag} ${prefix} ${dependency.name}@${dependency.version}`)
   }
 
-  // commit the updated shrinkwrap
-  exec('git add npm-shrinkwrap.json')
-  exec('git config user.email "support@greenkeeper.io"')
-  exec('git config user.name "greenkeeperio[bot]"')
-  const updateMessage = 'chore(package): update npm-shrinkwrap.json\n\nhttps://npm.im/greenkeeper-shrinkwrap'
-  exec(`git commit -m "${updateMessage}"`)
+  if (exec('git status --porcelain').toString() !== '') {
+    // commit the updated shrinkwrap
+    exec('git add npm-shrinkwrap.json')
+    exec('git config user.email "support@greenkeeper.io"')
+    exec('git config user.name "greenkeeperio[bot]"')
+    const updateMessage = 'chore(package): update npm-shrinkwrap.json\n\nhttps://npm.im/greenkeeper-shrinkwrap'
+    exec(`git commit -m "${updateMessage}"`)
+  }
 }


### PR DESCRIPTION
Fixes issue https://github.com/greenkeeperio/greenkeeper-shrinkwrap/issues/12.

Problem: NodeJS's latest LTS Version (v6.10.3) includes npm 3.10.10. This version of npm doesn't lock down devDependencies in the shrinkwrap file by default:

> Starting with npm v4.0.1, devDependencies are included when you run npm shrinkwrap and follow the usual rules as to when they're installed.
https://docs.npmjs.com/cli/shrinkwrap#other-notes

Right now, if a devDependency is updated by greenkeeper, greenkeeper tries to update the shrinkwrap as well. However, because the devDependencies are not locked down in the shrinkwrap, there are no changes. Therefore the git commit fails, because git doesn't allow empty commits by default. Which causes the Travis build to break. Which results in greenkeeper filing an issue in the user's repository for every devDependency that needs an update.

The fix is to first check if there is anything to commit, before actually applying the commit.